### PR TITLE
Wrong return type on optAlgo functions

### DIFF
--- a/include/mantella_bits/optimisationAlgorithm.hpp
+++ b/include/mantella_bits/optimisationAlgorithm.hpp
@@ -55,10 +55,10 @@ namespace mant {
     int nodeRank_;
     int numberOfNodes_;
    
-    std::function<arma::Col<double>(const arma::Mat<double>& parameters, const arma::Col<double>& differences)> nextParametersFunction_;
+    std::function<arma::Mat<double>(const arma::Mat<double>& parameters, const arma::Col<double>& differences)> nextParametersFunction_;
     std::function<arma::Mat<double>(const arma::Mat<double>& parameters)> boundaryHandlingFunction_;
     std::function<bool(const arma::Mat<double>& parameters, const arma::Col<double>& differences)> isDegeneratedFunction_;
-    std::function<arma::Col<double>(const arma::Mat<double>& parameters, const arma::Col<double>& differences)> degenerationHandlingFunction_;
+    std::function<arma::Mat<double>(const arma::Mat<double>& parameters, const arma::Col<double>& differences)> degenerationHandlingFunction_;
 
     double acceptableObjectiveValue_;
 


### PR DESCRIPTION
I'm 99,9% sure this is wrong and they should be Mats, since otherwise it obviously doesn't work for matrices (like in my cmaes case).